### PR TITLE
Make JitPack work

### DIFF
--- a/jitpack-download-natives.sh
+++ b/jitpack-download-natives.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+mkdir src/main/resources/
+
+version=$(git describe --tags --abbrev=0)
+
+curl -L -o src/main/resources/discord_game_sdk_jni.dll \
+	https://github.com/JnCrMx/discord-game-sdk4j/releases/download/$version/discord_game_sdk_jni.dll
+curl -L -o src/main/resources/libdiscord_game_sdk_jni.so \
+	https://github.com/JnCrMx/discord-game-sdk4j/releases/download/$version/libdiscord_game_sdk_jni.so

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,6 @@
+jdk:
+    - openjdk11
+before_install:
+    - sh jitpack-download-natives.sh
+install:
+    - mvn install -DskipTests -Dmaven.antrun.skip=true


### PR DESCRIPTION
We need to download the natives because we cannot build them on JitPack due to missing toolchain.