### PR TITLE
Support windows32

### DIFF
--- a/jitpack-download-natives.sh
+++ b/jitpack-download-natives.sh
@@ -6,5 +6,7 @@ version=$(git describe --tags --abbrev=0)
 
 curl -L -o src/main/resources/discord_game_sdk_jni.dll \
 	https://github.com/JnCrMx/discord-game-sdk4j/releases/download/$version/discord_game_sdk_jni.dll
+curl -L -o src/main/resources/discord_game_sdk_jni_32.dll \
+	https://github.com/JnCrMx/discord-game-sdk4j/releases/download/$version/discord_game_sdk_jni_32.dll
 curl -L -o src/main/resources/libdiscord_game_sdk_jni.so \
 	https://github.com/JnCrMx/discord-game-sdk4j/releases/download/$version/libdiscord_game_sdk_jni.so

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,18 @@
                             <target>
                                 <mkdir dir="${project.build.directory}/native"/>
                                 <exec executable="cmake" dir="${project.build.directory}/native" failonerror="true">
-                                    <arg line="-DCMAKE_BUILD_TYPE=Release ${basedir}/src/main/c"/>
+                                    <arg line="-DCMAKE_BUILD_TYPE=Release -DBUILDARCH=x86_64 ${basedir}/src/main/c"/>
                                 </exec>
                                 <exec executable="cmake" dir="${project.build.directory}/native" failonerror="true">
+                                    <arg line="--build . --config Release"/>
+                                </exec>
+                            </target>
+							<target>
+                                <mkdir dir="${project.build.directory}/native32"/>
+                                <exec executable="cmake" dir="${project.build.directory}/native32" failonerror="false">
+                                    <arg line="-DCMAKE_BUILD_TYPE=Release -A Win32 -DBUILDARCH=x86 ${basedir}/src/main/c"/>
+                                </exec>
+                                <exec executable="cmake" dir="${project.build.directory}/native32" failonerror="false">
                                     <arg line="--build . --config Release"/>
                                 </exec>
                             </target>
@@ -123,6 +132,20 @@
                                 </resource>
                                 <resource>
                                     <directory>${project.build.directory}/native/Release</directory>
+                                    <includes>
+                                        <include>discord_game_sdk_jni.dll</include>
+                                    </includes>
+                                    <filtering>false</filtering>
+                                </resource>
+								<resource>
+                                    <directory>${project.build.directory}/native32</directory>
+                                    <includes>
+                                        <include>libdiscord_game_sdk_jni.so</include>
+                                    </includes>
+                                    <filtering>false</filtering>
+                                </resource>
+                                <resource>
+                                    <directory>${project.build.directory}/native32/Release</directory>
                                     <includes>
                                         <include>discord_game_sdk_jni.dll</include>
                                     </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
                                     <arg line="--build . --config Release"/>
                                 </exec>
                             </target>
-							<target>
+                            <target>
                                 <mkdir dir="${project.build.directory}/native32"/>
                                 <exec executable="cmake" dir="${project.build.directory}/native32" failonerror="false">
                                     <arg line="-DCMAKE_BUILD_TYPE=Release -A Win32 -DBUILDARCH=x86 ${basedir}/src/main/c"/>
@@ -137,7 +137,7 @@
                                     </includes>
                                     <filtering>false</filtering>
                                 </resource>
-								<resource>
+                                <resource>
                                     <directory>${project.build.directory}/native32</directory>
                                     <includes>
                                         <include>libdiscord_game_sdk_jni.so</include>

--- a/src/main/c/CMakeLists.txt
+++ b/src/main/c/CMakeLists.txt
@@ -40,6 +40,6 @@ if(MSVC)
 	set_target_properties(discord_game_sdk
 		PROPERTIES
 		IMPORTED_IMPLIB
-		${CMAKE_SOURCE_DIR}/../../../discord_game_sdk/lib/x86_64/discord_game_sdk.dll.lib)
+		${CMAKE_SOURCE_DIR}/../../../discord_game_sdk/lib/${BUILDARCH}/discord_game_sdk.dll.lib)
 	target_link_libraries(discord_game_sdk_jni discord_game_sdk)
 endif(MSVC)

--- a/src/main/java/de/jcm/discordgamesdk/Core.java
+++ b/src/main/java/de/jcm/discordgamesdk/Core.java
@@ -31,9 +31,10 @@ public class Core implements AutoCloseable
 	 */
 	public static void init(File discordLibrary)
 	{
+		String jniLibraryName = getJniLibraryName();
 		try
 		{
-			System.loadLibrary("discord_game_sdk_jni");
+			System.loadLibrary(jniLibraryName);
 		}
 		catch(UnsatisfiedLinkError e)
 		{
@@ -42,11 +43,11 @@ public class Core implements AutoCloseable
 				if(System.getProperty("os.name").toLowerCase().contains("windows"))
 				{
 					System.load(discordLibrary.getAbsolutePath());
-					NativeUtils.loadLibraryFromJar("/"+"discord_game_sdk_jni"+".dll");
+					NativeUtils.loadLibraryFromJar("/"+jniLibraryName+".dll");
 				}
 				else
 				{
-					NativeUtils.loadLibraryFromJar("/"+"lib"+"discord_game_sdk_jni"+".so");
+					NativeUtils.loadLibraryFromJar("/lib"+jniLibraryName+".so");
 				}
 			}
 			catch(IOException ex)
@@ -54,7 +55,35 @@ public class Core implements AutoCloseable
 				ex.printStackTrace();
 			}
 		}
-		initDiscordNative(discordLibrary.getAbsolutePath());
+		initManual(discordLibrary.getAbsolutePath());
+	}
+
+	/**
+	 * <p> Initialize the native library.
+	 * You need manually load Discord's native libraries before calling this method. </p>
+	 *
+	 * <p>You may call this method more than once which unloads the old shared object and loads the new one.</p>
+	 *
+	 * @param discordLibrary Location of Discord's native library.
+	 *                       <p>On Windows the filename (last component of the path) must be
+	 *                       "discord_game_sdk.dll" or an {@link UnsatisfiedLinkError} will occur.</p>
+	 *                       <p>On Linux the filename does not matter.</p>
+	 *
+	 * @throws UnsatisfiedLinkError if Discord's native library can not be loaded
+	 */
+	public static void initManual(String discordLibrary) {
+		initDiscordNative(discordLibrary);
+	}
+
+	private static String getJniLibraryName() {
+		String bits = System.getProperty("sun.arch.data.model");
+		String jniLibraryName;
+		if("32".equals(bits)) {
+			jniLibraryName = "discord_game_sdk_jni_32";
+		} else {
+			jniLibraryName = "discord_game_sdk_jni";
+		}
+		return jniLibraryName;
 	}
 
 	private static native void initDiscordNative(String discordPath);


### PR DESCRIPTION
In Windows, building target/natives32 normally
In Linux, show error without building failure