### PR TITLE
Add Core#isOpen public method, add CoreClosedException

### DIFF
--- a/src/main/java/de/jcm/discordgamesdk/Core.java
+++ b/src/main/java/de/jcm/discordgamesdk/Core.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -449,7 +448,7 @@ public class Core implements AutoCloseable
 	<T> T execute(Supplier<T> provider)
 	{
 		if(!open.get())
-			throw new IllegalStateException("Core is closed");
+			throw new CoreClosedException();
 
 		lock.lock();
 		try

--- a/src/main/java/de/jcm/discordgamesdk/Core.java
+++ b/src/main/java/de/jcm/discordgamesdk/Core.java
@@ -402,6 +402,17 @@ public class Core implements AutoCloseable
 	}
 
 	/**
+	 * Returns true if this {@link Core} instance is open, i.e. {@link #close()} has not
+	 * been called yet. Calling certain SDK methods will throw {@link CoreClosedException}
+	 * if the {@link Core} is not open.
+	 * @return True if this {@link Core} is still open, false otherwise
+	 */
+	public boolean isOpen()
+	{
+		return open.get();
+	}
+
+	/**
 	 * <p>Closes and destroys the instance.</p>
 	 * <p>This should be called at the end of the program.</p>
 	 *
@@ -447,7 +458,7 @@ public class Core implements AutoCloseable
 
 	<T> T execute(Supplier<T> provider)
 	{
-		if(!open.get())
+		if(!isOpen())
 			throw new CoreClosedException();
 
 		lock.lock();

--- a/src/main/java/de/jcm/discordgamesdk/CoreClosedException.java
+++ b/src/main/java/de/jcm/discordgamesdk/CoreClosedException.java
@@ -1,0 +1,13 @@
+package de.jcm.discordgamesdk;
+
+/**
+ * Exception which is thrown when attempting to execute an SDK operation
+ * when the {@link Core} has been closed.
+ */
+public class CoreClosedException extends IllegalStateException
+{
+	public CoreClosedException()
+	{
+		super("Core is closed");
+	}
+}


### PR DESCRIPTION
The `open` `AtomicBoolean` field in `Core` is not publicly gettable, so I added a boolean getter `Core#isOpen()`. Additionally, I subclassed `IllegalStateException` and created `CoreClosedException` which is easier to catch for than a plain `IllegalStateException`.

My rationale for this change is that any of the SDK methods that eventually call (the package-private) `Core#execute` method may throw an IllegalArgumentException if the Core is unexpectedly closed. I would prefer to avoid exception-based handling as a user of this library, so being able to check if the Core is open or not is useful. The `CoreClosedException` was my original plan since I could catch-filter for it, but I think both options are flexible.