### PR TITLE
Deprecate `Activity#close` method and update Javadoc

### DIFF
--- a/src/main/java/de/jcm/discordgamesdk/activity/Activity.java
+++ b/src/main/java/de/jcm/discordgamesdk/activity/Activity.java
@@ -187,10 +187,10 @@ public class Activity implements AutoCloseable
 	}
 
 	/**
-	 * <p>Frees the allocated native structure and therefore also all embedded native structures.</p>
-	 * <p>You should call this when you do not need the structure anymore.</p>
+	 * No operation, only kept for backwards compatibility
 	 */
 	@Override
+	@Deprecated
 	public void close()
 	{
 	}


### PR DESCRIPTION
Updated the `Activity#close` to reflect the changes in the Java implementation, based on `CreateParams#close`.

Tiny PR, but I noticed this was missed when finishing porting my code.