### PR TITLE
Add check, if a connection to Discord is available

### DIFF
--- a/src/main/java/de/jcm/discordgamesdk/Core.java
+++ b/src/main/java/de/jcm/discordgamesdk/Core.java
@@ -444,11 +444,8 @@ public class Core implements AutoCloseable
 		}
 	}
 
-	public void isDiscordRunning() {
-		if (!channel.isAvailable())
-		{
-			throw new RuntimeException("Discord is not running");
-		}
+	public boolean isDiscordRunning() {
+		return channel.isAvailable();
 	}
 
 	/**

--- a/src/main/java/de/jcm/discordgamesdk/Core.java
+++ b/src/main/java/de/jcm/discordgamesdk/Core.java
@@ -444,10 +444,10 @@ public class Core implements AutoCloseable
 		}
 	}
 
-	public void checkConnection() {
-		if (!channel.isConnected())
+	public void isDiscordRunning() {
+		if (!channel.isAvailable())
 		{
-			throw new RuntimeException("Channel is not connected");
+			throw new RuntimeException("Discord is not running");
 		}
 	}
 

--- a/src/main/java/de/jcm/discordgamesdk/Core.java
+++ b/src/main/java/de/jcm/discordgamesdk/Core.java
@@ -444,6 +444,13 @@ public class Core implements AutoCloseable
 		}
 	}
 
+	public void checkConnection() {
+		if (!channel.isConnected())
+		{
+			throw new RuntimeException("Channel is not connected");
+		}
+	}
+
 	/**
 	 * Registers a log function.
 	 * @param minLevel Minimal level of message to receive.

--- a/src/main/java/de/jcm/discordgamesdk/impl/channel/DiscordChannel.java
+++ b/src/main/java/de/jcm/discordgamesdk/impl/channel/DiscordChannel.java
@@ -9,5 +9,5 @@ public interface DiscordChannel {
 	public int read(ByteBuffer dst) throws IOException;
 	public long read(ByteBuffer[] dsts, int offset, int length) throws IOException;
 	public int write(ByteBuffer src) throws IOException;
-	public boolean isConnected();
+	public boolean isAvailable();
 }

--- a/src/main/java/de/jcm/discordgamesdk/impl/channel/DiscordChannel.java
+++ b/src/main/java/de/jcm/discordgamesdk/impl/channel/DiscordChannel.java
@@ -9,4 +9,5 @@ public interface DiscordChannel {
 	public int read(ByteBuffer dst) throws IOException;
 	public long read(ByteBuffer[] dsts, int offset, int length) throws IOException;
 	public int write(ByteBuffer src) throws IOException;
+	public boolean isConnected();
 }

--- a/src/main/java/de/jcm/discordgamesdk/impl/channel/UnixDiscordChannel.java
+++ b/src/main/java/de/jcm/discordgamesdk/impl/channel/UnixDiscordChannel.java
@@ -75,7 +75,7 @@ public class UnixDiscordChannel implements DiscordChannel {
 		channel.configureBlocking(block);
 	}
 
-	public boolean isConnected() {
+	public boolean isAvailable() {
 		return new File(path).exists();
 	}
 

--- a/src/main/java/de/jcm/discordgamesdk/impl/channel/UnixDiscordChannel.java
+++ b/src/main/java/de/jcm/discordgamesdk/impl/channel/UnixDiscordChannel.java
@@ -76,7 +76,7 @@ public class UnixDiscordChannel implements DiscordChannel {
 	}
 
 	public boolean isAvailable() {
-		return new File(path).exists();
+		return new File(path).exists() && channel.isConnected();
 	}
 
 	public int read(ByteBuffer dst) throws IOException {

--- a/src/main/java/de/jcm/discordgamesdk/impl/channel/UnixDiscordChannel.java
+++ b/src/main/java/de/jcm/discordgamesdk/impl/channel/UnixDiscordChannel.java
@@ -13,6 +13,7 @@ import java.util.stream.IntStream;
 
 public class UnixDiscordChannel implements DiscordChannel {
 	private final SocketChannel channel;
+	private String path;
 
 	private static String[] getSockets()
 	{
@@ -48,7 +49,7 @@ public class UnixDiscordChannel implements DiscordChannel {
 	}
 
 	public UnixDiscordChannel() throws IOException {
-		String path = System.getenv("DISCORD_IPC_PATH");
+		path = System.getenv("DISCORD_IPC_PATH");
 		if(path == null) {
 			String instance = System.getenv("DISCORD_INSTANCE_ID");
 			int i = 0;
@@ -72,6 +73,10 @@ public class UnixDiscordChannel implements DiscordChannel {
 
 	public void configureBlocking(boolean block) throws IOException {
 		channel.configureBlocking(block);
+	}
+
+	public boolean isConnected() {
+		return new File(path).exists();
 	}
 
 	public int read(ByteBuffer dst) throws IOException {

--- a/src/main/java/de/jcm/discordgamesdk/impl/channel/WindowsDiscordChannel.java
+++ b/src/main/java/de/jcm/discordgamesdk/impl/channel/WindowsDiscordChannel.java
@@ -34,7 +34,7 @@ public class WindowsDiscordChannel implements DiscordChannel {
 	}
 
 	public boolean isAvailable() {
-		return new File(path).exists();
+		return new File(path).exists() && channel.isOpen();
 	}
 
 	public int read(ByteBuffer dst) throws IOException {

--- a/src/main/java/de/jcm/discordgamesdk/impl/channel/WindowsDiscordChannel.java
+++ b/src/main/java/de/jcm/discordgamesdk/impl/channel/WindowsDiscordChannel.java
@@ -33,7 +33,7 @@ public class WindowsDiscordChannel implements DiscordChannel {
 		blocking = block;
 	}
 
-	public boolean isConnected() {
+	public boolean isAvailable() {
 		return new File(path).exists();
 	}
 

--- a/src/main/java/de/jcm/discordgamesdk/impl/channel/WindowsDiscordChannel.java
+++ b/src/main/java/de/jcm/discordgamesdk/impl/channel/WindowsDiscordChannel.java
@@ -1,5 +1,6 @@
 package de.jcm.discordgamesdk.impl.channel;
 
+import java.io.File;
 import java.io.RandomAccessFile;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -8,9 +9,10 @@ import java.nio.channels.FileChannel;
 public class WindowsDiscordChannel implements DiscordChannel {
 	private final FileChannel channel;
 	private boolean blocking = true;
+	private String path;
 
 	public WindowsDiscordChannel() throws IOException {
-		String path = System.getenv("DISCORD_IPC_PATH");
+		path = System.getenv("DISCORD_IPC_PATH");
 		if(path == null) {
 			String instance = System.getenv("DISCORD_INSTANCE_ID");
 			int i = 0;
@@ -29,6 +31,10 @@ public class WindowsDiscordChannel implements DiscordChannel {
 
 	public void configureBlocking(boolean block) throws IOException {
 		blocking = block;
+	}
+
+	public boolean isConnected() {
+		return new File(path).exists();
 	}
 
 	public int read(ByteBuffer dst) throws IOException {


### PR DESCRIPTION
This PR introduces a new core method `isDiscordRunning()` as suggested in #76. The method throws a runtime exception, if a connection to Discord is not available.

The connection check itself is implemented in the classes `UnixDiscordChannel` and `WindowsDiscordChannel`. A new method `isAvailable()` has been added to both classes for this purpose. The method will return true, if the socket/pipe file exists and the channel is connected/open.

The general idea is that the implementing app calls `isDiscordRunning()` regularly to check whether Discord is still available or not. It lays within the responsibility of the app to handle exceptions. Typically the currently active core should be destroyed as soon as Discord is not running anymore and a new core should be created when Discord is running again.

An example implementation can be found in [the main class of the Discord Rich Presence tool for Processing](https://github.com/letorbi/discord-rich-presence-for-processing/blob/956d6474d28121cc902027e8e223b16b9e853fe5/tool/src/main/java/com/letorbi/DiscordRichPresence/DiscordRichPresence.java#L34)

The code for the Unix channel has has been tested under Linux, but the Windows functionality still needs to be tested.

* [x] Check Unix channel functionality
* [x] Check Windows channel functionality