### PR TITLE
Suggest an alternative path to discord ipc pipe on windows

### DIFF
--- a/src/main/java/de/jcm/discordgamesdk/impl/channel/WindowsDiscordChannel.java
+++ b/src/main/java/de/jcm/discordgamesdk/impl/channel/WindowsDiscordChannel.java
@@ -1,6 +1,7 @@
 package de.jcm.discordgamesdk.impl.channel;
 
 import java.io.RandomAccessFile;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -11,6 +12,7 @@ public class WindowsDiscordChannel implements DiscordChannel {
 
 	public WindowsDiscordChannel() throws IOException {
 		String path = System.getenv("DISCORD_IPC_PATH");
+		String exceptionalPath = path;
 		if(path == null) {
 			String instance = System.getenv("DISCORD_INSTANCE_ID");
 			int i = 0;
@@ -18,8 +20,12 @@ public class WindowsDiscordChannel implements DiscordChannel {
 				i = Integer.parseInt(instance);
 			}
 			path = "\\\\?\\pipe\\discord-ipc-"+i;
+			exceptionalPath = "\\\\.\\\\pipe\\\\discord-ipc-" + i;
 		}
-		RandomAccessFile raf = new RandomAccessFile(path, "rw");
+		File pipe = new File(path);
+		String finalPath = exceptionalPath;
+		if(pipe.exists()) finalPath = path;
+		RandomAccessFile raf = new RandomAccessFile(finalPath, "rw");
 		channel = raf.getChannel();
 	}
 

--- a/src/main/java/de/jcm/discordgamesdk/impl/channel/WindowsDiscordChannel.java
+++ b/src/main/java/de/jcm/discordgamesdk/impl/channel/WindowsDiscordChannel.java
@@ -12,20 +12,15 @@ public class WindowsDiscordChannel implements DiscordChannel {
 
 	public WindowsDiscordChannel() throws IOException {
 		String path = System.getenv("DISCORD_IPC_PATH");
-		String exceptionalPath = path;
 		if(path == null) {
 			String instance = System.getenv("DISCORD_INSTANCE_ID");
 			int i = 0;
 			if (instance != null) {
 				i = Integer.parseInt(instance);
 			}
-			path = "\\\\?\\pipe\\discord-ipc-"+i;
-			exceptionalPath = "\\\\.\\\\pipe\\\\discord-ipc-" + i;
+			path = "\\\\.\\\\pipe\\\\discord-ipc-" + i;
 		}
-		File pipe = new File(path);
-		String finalPath = exceptionalPath;
-		if(pipe.exists()) finalPath = path;
-		RandomAccessFile raf = new RandomAccessFile(finalPath, "rw");
+		RandomAccessFile raf = new RandomAccessFile(path, "rw");
 		channel = raf.getChannel();
 	}
 


### PR DESCRIPTION
I was getting `java.lang.RuntimeException: java.io.FileNotFoundException: pipe\discord-ipc-0 (The system cannot find the path specified)` on my windows instance. i've done quick research and find out that `"\\\\?\\pipe\\discord-ipc-"+i` may be not the only path to the discord ipc pipe. So I've added an exceptional pipe path: `"\\\\.\\\\pipe\\\\discord-ipc-" + i` in the code. Now it checks if original path exists and sets alternative path if not.

The pull requested code was tested on Windows 11 23H2