### PR TITLE
Start and End Activity Timestamp should not be Mutually Exclusive

### DIFF
--- a/src/main/java/de/jcm/discordgamesdk/activity/ActivityTimestamps.java
+++ b/src/main/java/de/jcm/discordgamesdk/activity/ActivityTimestamps.java
@@ -20,7 +20,6 @@ public class ActivityTimestamps
 	public void setStart(Instant start)
 	{
 		this.start = start.getEpochSecond();
-		this.end = null;
 	}
 
 	/**
@@ -39,7 +38,6 @@ public class ActivityTimestamps
 	 */
 	public void setEnd(Instant end)
 	{
-		this.start = null;
 		this.end = end.getEpochSecond();
 	}
 


### PR DESCRIPTION
Hey, I noticed in your library when you set a start timestamp or an end timestamp, it sets the other to null.

For Listening and Watching activities, they support both a start and end timestamp to render a 'progress bar'-like element on the user's profile as seen below:

<img width="215" alt="vp5uGKf" src="https://github.com/user-attachments/assets/3774f53c-61c3-402f-8b0a-839e7d2dfcae" />

This pull request simply removes the two lines that clear the opposing timestamp field because providing both timestamps is the only way to make this progress bar appear.
I've already tested these changes locally and it's how I was able to create that example above.

Thanks for this project and I hope you will merge this & tag a new release soon!
@JnCrMx 