### PR TITLE
ActivityType.UNUSED rename to WATCHING

### DIFF
--- a/src/main/java/de/jcm/discordgamesdk/activity/ActivityType.java
+++ b/src/main/java/de/jcm/discordgamesdk/activity/ActivityType.java
@@ -16,7 +16,7 @@ public enum ActivityType
 	PLAYING,
 	STREAMING,
 	LISTENING,
-	UNUSED,
+	WATCHING,
 	CUSTOM,
 	COMPETING
 }


### PR DESCRIPTION
This ActivityType is no longer unused, and is the WATCHING type, as per the docs: https://discord.com/developers/docs/developer-tools/game-sdk#activitytype-enum